### PR TITLE
Replace deprecated TNS hostnames with Mastercard

### DIFF
--- a/src/main/java/com/gateway/client/ApiRequestService.java
+++ b/src/main/java/com/gateway/client/ApiRequestService.java
@@ -565,7 +565,7 @@ public class ApiRequestService {
      * @param config
      * @return the API Operation corresponding to the available options for processing a payment
      * @throws Exception
-     * @see https://secure.uat.tnspayments.com/api/documentation/apiDocumentation/rest-json/version/latest/operation/Gateway%3a%20%20Payment%20Options%20Inquiry.html?locale=en_US
+     * @see https://mtf.gateway.mastercard.com/api/documentation/apiDocumentation/rest-json/version/latest/operation/Gateway%3a%20%20Payment%20Options%20Inquiry.html?locale=en_US
      */
     public static PaymentOptionsResponse retrievePaymentOptionsInquiry(Config config) throws Exception {
         String paymentOptionsInquiryUrl =
@@ -604,7 +604,7 @@ public class ApiRequestService {
      * @param config
      * @return the API Operation corresponding to the available options for processing a payment
      * @throws Exception
-     * @see https://secure.uat.tnspayments.com/api/documentation/apiDocumentation/rest-json/version/latest/operation/Gateway%3a%20%20Payment%20Options%20Inquiry.html?locale=en_US
+     * @see https://mtf.gateway.mastercard.com/api/documentation/apiDocumentation/rest-json/version/latest/operation/Gateway%3a%20%20Payment%20Options%20Inquiry.html?locale=en_US
      */
     public static ApiOperation getApiOperationFromPaymentOptionsInquiry(Config config) throws Exception {
         if (config.getTransactionMode() == null && config.getSupportedPaymentOperations() == null) {

--- a/src/main/java/com/gateway/client/ApiRequestService.java
+++ b/src/main/java/com/gateway/client/ApiRequestService.java
@@ -565,7 +565,7 @@ public class ApiRequestService {
      * @param config
      * @return the API Operation corresponding to the available options for processing a payment
      * @throws Exception
-     * @see https://mtf.gateway.mastercard.com/api/documentation/apiDocumentation/rest-json/version/latest/operation/Gateway%3a%20%20Payment%20Options%20Inquiry.html?locale=en_US
+     * @see https://test-gateway.mastercard.com/api/documentation/apiDocumentation/rest-json/version/latest/operation/Gateway%3a%20%20Payment%20Options%20Inquiry.html?locale=en_US
      */
     public static PaymentOptionsResponse retrievePaymentOptionsInquiry(Config config) throws Exception {
         String paymentOptionsInquiryUrl =
@@ -604,7 +604,7 @@ public class ApiRequestService {
      * @param config
      * @return the API Operation corresponding to the available options for processing a payment
      * @throws Exception
-     * @see https://mtf.gateway.mastercard.com/api/documentation/apiDocumentation/rest-json/version/latest/operation/Gateway%3a%20%20Payment%20Options%20Inquiry.html?locale=en_US
+     * @see https://test-gateway.mastercard.com/api/documentation/apiDocumentation/rest-json/version/latest/operation/Gateway%3a%20%20Payment%20Options%20Inquiry.html?locale=en_US
      */
     public static ApiOperation getApiOperationFromPaymentOptionsInquiry(Config config) throws Exception {
         if (config.getTransactionMode() == null && config.getSupportedPaymentOperations() == null) {

--- a/src/main/resources/public/scripts/hostedSession.js
+++ b/src/main/resources/public/scripts/hostedSession.js
@@ -4,8 +4,8 @@
 
 /**
  *    The Hosted Session JavaScript client library enables you to collect sensitive payment details from the payer in
- *    payment form fields, hosted by the Mastercard Payment Gateway. For more information, see {@link https://secure.uat.tnspayments.com/api/documentation/integrationGuidelines/supportedFeatures/pickAdditionalFunctionality/paymentSession.html payment session}
- *    See https://secure.uat.tnspayments.com/api/documentation/integrationGuidelines/hostedSession/integrationModelHostedSession.html Implementing a Hosted Session Integration
+ *    payment form fields, hosted by the Mastercard Payment Gateway. For more information, see {@link https://mtf.gateway.mastercard.com/api/documentation/integrationGuidelines/supportedFeatures/pickAdditionalFunctionality/paymentSession.html payment session}
+ *    See https://mtf.gateway.mastercard.com/api/documentation/integrationGuidelines/hostedSession/integrationModelHostedSession.html Implementing a Hosted Session Integration
  */
 
 // APPLY CLICK-JACKING STYLING AND HIDE CONTENTS OF THE PAGE

--- a/src/main/resources/public/scripts/hostedSession.js
+++ b/src/main/resources/public/scripts/hostedSession.js
@@ -4,8 +4,8 @@
 
 /**
  *    The Hosted Session JavaScript client library enables you to collect sensitive payment details from the payer in
- *    payment form fields, hosted by the Mastercard Payment Gateway. For more information, see {@link https://mtf.gateway.mastercard.com/api/documentation/integrationGuidelines/supportedFeatures/pickAdditionalFunctionality/paymentSession.html payment session}
- *    See https://mtf.gateway.mastercard.com/api/documentation/integrationGuidelines/hostedSession/integrationModelHostedSession.html Implementing a Hosted Session Integration
+ *    payment form fields, hosted by the Mastercard Payment Gateway. For more information, see {@link https://test-gateway.mastercard.com/api/documentation/integrationGuidelines/supportedFeatures/pickAdditionalFunctionality/paymentSession.html payment session}
+ *    See https://test-gateway.mastercard.com/api/documentation/integrationGuidelines/hostedSession/integrationModelHostedSession.html Implementing a Hosted Session Integration
  */
 
 // APPLY CLICK-JACKING STYLING AND HIDE CONTENTS OF THE PAGE


### PR DESCRIPTION
Post the acquisition of TNSPay assets by Mastercard, *.tnspayments.com is deprecated in favour of *.gateway.mastercard.com
